### PR TITLE
change name_* options to receive functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ iex> NimbleStrftime.format(datetime, "%c", preferred_datetime: "%H:%M:%S %d-%m-%
 iex> NimbleStrftime.format(
 ...>  datetime,
 ...>  "%A",
-...>  day_of_week_names: fn index ->
+...>  day_of_week: fn index ->
 ...>    {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira",
 ...>    "sexta-feira", "sábado", "domingo"}
 ...>    |> elem(index - 1)
@@ -50,7 +50,7 @@ iex> NimbleStrftime.format(
 ...>  datetime,
 ...>  "%B",
 ...>  abbreviation_size: 2,
-...>  month_names: fn index ->
+...>  month: fn index ->
 ...>    {"январь", "февраль", "март", "апрель", "май", "июнь",
 ...>    "июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь"}
 ...>    |> elem(index - 1)

--- a/README.md
+++ b/README.md
@@ -37,15 +37,11 @@ iex> NimbleStrftime.format(datetime, "%c", preferred_datetime: "%H:%M:%S %d-%m-%
 iex> NimbleStrftime.format(
 ...>  datetime,
 ...>  "%A",
-...>  day_of_week_names: ~w(
-...>    segunda-feira
-...>    terça-feira
-...>    quarta-feira
-...>    quinta-feira
-...>    sexta-feira
-...>    sábado
-...>    domingo
-...>  )
+...>  day_of_week_names: fn index ->
+...>    {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira",
+...>    "sexta-feira", "sábado", "domingo"}
+...>    |> elem(index - 1)
+...>  end
 ...>)
 "segunda-feira"
 
@@ -54,20 +50,11 @@ iex> NimbleStrftime.format(
 ...>  datetime,
 ...>  "%B",
 ...>  abbreviation_size: 2,
-...>  month_names: ~w(
-...>    январь
-...>    февраль
-...>    март
-...>    апрель
-...>    май
-...>    июнь
-...>    июль
-...>    август
-...>    сентябрь
-...>    октябрь
-...>    ноябрь
-...>    декабрь
-...>  )
+...>  month_names: fn index ->
+...>    {"январь", "февраль", "март", "апрель", "май", "июнь",
+...>    "июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь"}
+...>    |> elem(index - 1)
+...>  end
 ...>)
 # => "ав"
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ iex> NimbleStrftime.format(datetime, "%c", preferred_datetime: "%H:%M:%S %d-%m-%
 iex> NimbleStrftime.format(
 ...>  datetime,
 ...>  "%A",
-...>  day_of_week: fn index ->
+...>  day_of_week_names: fn day_of_week ->
 ...>    {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira",
 ...>    "sexta-feira", "sábado", "domingo"}
 ...>    |> elem(index - 1)
@@ -50,7 +50,7 @@ iex> NimbleStrftime.format(
 ...>  datetime,
 ...>  "%B",
 ...>  abbreviation_size: 2,
-...>  month: fn index ->
+...>  month_names: fn month ->
 ...>    {"январь", "февраль", "март", "апрель", "май", "июнь",
 ...>    "июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь"}
 ...>    |> elem(index - 1)

--- a/lib/nimble_strftime.ex
+++ b/lib/nimble_strftime.ex
@@ -81,15 +81,15 @@ defmodule NimbleStrftime do
       it can't contain the `%X` format and defaults to `"%H:%M:%S"`
       if the option is not received
 
-    * `:am_pm_names` - a function that receives either `:am` or `:pm` and returns
+    * `:am_pm` - a function that receives either `:am` or `:pm` and returns
       the name of the period of the day, if the option is not received it defaults
       to a function that returns `"am"` and `"pm"`, respectively
 
-    *  `:month_names` - a function that receives a number and returns the name of
+    *  `:month` - a function that receives a number and returns the name of
       the corresponding month, if the option is not received it defaults to a
       function thet returns the month names in english
 
-    * `:day_of_week_names` - a function that receives a number and returns the name of
+    * `:day_of_week` - a function that receives a number and returns the name of
       the corresponding day of week, if the option is not received it defaults to a
       function that returns the day of week names in english
 
@@ -117,7 +117,7 @@ defmodule NimbleStrftime do
       iex> NimbleStrftime.format(
       ...>  ~U[2019-08-26 13:52:06.0Z],
       ...>  "%A",
-      ...>  day_of_week_names: fn index ->
+      ...>  day_of_week: fn index ->
       ...>    {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira",
       ...>    "sexta-feira", "sábado", "domingo"}
       ...>    |> elem(index - 1)
@@ -128,7 +128,7 @@ defmodule NimbleStrftime do
       iex> NimbleStrftime.format(
       ...>  ~U[2019-08-26 13:52:06.0Z],
       ...>  "%B",
-      ...>  month_names: fn index ->
+      ...>  month: fn index ->
       ...>    {"январь", "февраль", "март", "апрель", "май", "июнь",
       ...>    "июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь"}
       ...>    |> elem(index - 1)
@@ -193,20 +193,20 @@ defmodule NimbleStrftime do
   end
 
   defp am_pm(hour, format_options) when hour > 11 do
-    format_options.am_pm_names.(:pm)
+    format_options.am_pm.(:pm)
   end
 
   defp am_pm(hour, format_options) when hour <= 11 do
-    format_options.am_pm_names.(:am)
+    format_options.am_pm.(:am)
   end
 
   defp month_name_abbreviated(index, format_options) do
-    String.slice(format_options.month_names.(index), 0..(format_options.abbreviation_size - 1))
+    String.slice(format_options.month.(index), 0..(format_options.abbreviation_size - 1))
   end
 
   defp day_of_week_name_abbreviated(index, format_options) do
     String.slice(
-      format_options.day_of_week_names.(index),
+      format_options.day_of_week.(index),
       0..(format_options.abbreviation_size - 1)
     )
   end
@@ -240,7 +240,7 @@ defmodule NimbleStrftime do
     result =
       datetime
       |> Date.day_of_week()
-      |> format_options.day_of_week_names.()
+      |> format_options.day_of_week.()
       |> pad_leading(width, pad)
 
     parse(rest, datetime, format_options, [result | acc])
@@ -258,7 +258,7 @@ defmodule NimbleStrftime do
 
   # Full month name
   defp format_modifiers("B" <> rest, width, pad, datetime, format_options, acc) do
-    result = datetime.month |> format_options.month_names.() |> pad_leading(width, pad)
+    result = datetime.month |> format_options.month.() |> pad_leading(width, pad)
 
     parse(rest, datetime, format_options, [result | acc])
   end
@@ -476,16 +476,16 @@ defmodule NimbleStrftime do
       preferred_date: "%Y-%m-%d",
       preferred_time: "%H:%M:%S",
       preferred_datetime: "%Y-%m-%d %H:%M:%S",
-      am_pm_names: fn
+      am_pm: fn
         :am -> "am"
         :pm -> "pm"
       end,
-      month_names: fn index ->
+      month: fn index ->
         {"January", "February", "March", "April", "May", "June", "July", "August", "September",
          "October", "November", "December"}
         |> elem(index - 1)
       end,
-      day_of_week_names: fn index ->
+      day_of_week: fn index ->
         {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
         |> elem(index - 1)
       end,

--- a/lib/nimble_strftime.ex
+++ b/lib/nimble_strftime.ex
@@ -81,15 +81,15 @@ defmodule NimbleStrftime do
       it can't contain the `%X` format and defaults to `"%H:%M:%S"`
       if the option is not received
 
-    * `:am_pm` - a function that receives either `:am` or `:pm` and returns
+    * `:am_pm_names` - a function that receives either `:am` or `:pm` and returns
       the name of the period of the day, if the option is not received it defaults
       to a function that returns `"am"` and `"pm"`, respectively
 
-    *  `:month` - a function that receives a number and returns the name of
+    *  `:month_names` - a function that receives a number and returns the name of
       the corresponding month, if the option is not received it defaults to a
       function thet returns the month names in english
 
-    * `:day_of_week` - a function that receives a number and returns the name of
+    * `:day_of_week_names` - a function that receives a number and returns the name of
       the corresponding day of week, if the option is not received it defaults to a
       function that returns the day of week names in english
 
@@ -117,10 +117,10 @@ defmodule NimbleStrftime do
       iex> NimbleStrftime.format(
       ...>  ~U[2019-08-26 13:52:06.0Z],
       ...>  "%A",
-      ...>  day_of_week: fn index ->
+      ...>  day_of_week_names: fn day_of_week ->
       ...>    {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira",
       ...>    "sexta-feira", "sábado", "domingo"}
-      ...>    |> elem(index - 1)
+      ...>    |> elem(day_of_week - 1)
       ...>  end
       ...>)
       "segunda-feira"
@@ -128,10 +128,10 @@ defmodule NimbleStrftime do
       iex> NimbleStrftime.format(
       ...>  ~U[2019-08-26 13:52:06.0Z],
       ...>  "%B",
-      ...>  month: fn index ->
+      ...>  month_names: fn month ->
       ...>    {"январь", "февраль", "март", "апрель", "май", "июнь",
       ...>    "июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь"}
-      ...>    |> elem(index - 1)
+      ...>    |> elem(month - 1)
       ...>  end
       ...>)
       "август"
@@ -193,20 +193,20 @@ defmodule NimbleStrftime do
   end
 
   defp am_pm(hour, format_options) when hour > 11 do
-    format_options.am_pm.(:pm)
+    format_options.am_pm_names.(:pm)
   end
 
   defp am_pm(hour, format_options) when hour <= 11 do
-    format_options.am_pm.(:am)
+    format_options.am_pm_names.(:am)
   end
 
-  defp month_name_abbreviated(index, format_options) do
-    String.slice(format_options.month.(index), 0..(format_options.abbreviation_size - 1))
+  defp month_name_abbreviated(month, format_options) do
+    String.slice(format_options.month_names.(month), 0..(format_options.abbreviation_size - 1))
   end
 
-  defp day_of_week_name_abbreviated(index, format_options) do
+  defp day_of_week_name_abbreviated(day_of_week, format_options) do
     String.slice(
-      format_options.day_of_week.(index),
+      format_options.day_of_week_names.(day_of_week),
       0..(format_options.abbreviation_size - 1)
     )
   end
@@ -240,7 +240,7 @@ defmodule NimbleStrftime do
     result =
       datetime
       |> Date.day_of_week()
-      |> format_options.day_of_week.()
+      |> format_options.day_of_week_names.()
       |> pad_leading(width, pad)
 
     parse(rest, datetime, format_options, [result | acc])
@@ -258,7 +258,7 @@ defmodule NimbleStrftime do
 
   # Full month name
   defp format_modifiers("B" <> rest, width, pad, datetime, format_options, acc) do
-    result = datetime.month |> format_options.month.() |> pad_leading(width, pad)
+    result = datetime.month |> format_options.month_names.() |> pad_leading(width, pad)
 
     parse(rest, datetime, format_options, [result | acc])
   end
@@ -476,18 +476,18 @@ defmodule NimbleStrftime do
       preferred_date: "%Y-%m-%d",
       preferred_time: "%H:%M:%S",
       preferred_datetime: "%Y-%m-%d %H:%M:%S",
-      am_pm: fn
+      am_pm_names: fn
         :am -> "am"
         :pm -> "pm"
       end,
-      month: fn index ->
+      month_names: fn month ->
         {"January", "February", "March", "April", "May", "June", "July", "August", "September",
          "October", "November", "December"}
-        |> elem(index - 1)
+        |> elem(month - 1)
       end,
-      day_of_week: fn index ->
+      day_of_week_names: fn day_of_week ->
         {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
-        |> elem(index - 1)
+        |> elem(day_of_week - 1)
       end,
       abbreviation_size: 3,
       preferred_datetime_invoked: false,

--- a/lib/nimble_strftime.ex
+++ b/lib/nimble_strftime.ex
@@ -81,14 +81,17 @@ defmodule NimbleStrftime do
       it can't contain the `%X` format and defaults to `"%H:%M:%S"`
       if the option is not received
 
-    * `:am_pm_names` - a tuple for the terms to be used as `am` and `pm`, respectively
-      it defaults to `{"am", "pm"}` if the option is not received
+    * `:am_pm_names` - a function that receives either `:am` or `:pm` and returns
+      the name of the period of the day, if the option is not received it defaults
+      to a function that returns `"am"` and `"pm"`, respectively
 
-    *  `:month_names` - a list with month names in order, defaults to a list of
-      month names in english if the option is not received
+    *  `:month_names` - a function that receives a number and returns the name of
+      the corresponding month, if the option is not received it defaults to a
+      function thet returns the month names in english
 
-    * `:day_of_week_names` - a list with the name of the days in the week, defaults
-      to the name of the days of week in english if the option is not received
+    * `:day_of_week_names` - a function that receives a number and returns the name of
+      the corresponding day of week, if the option is not received it defaults to a
+      function that returns the day of week names in english
 
     * `:abbreviation_size` - number of characters shown in abbreviated
       month and week day names, if the option is not received the default of 3 is set

--- a/test/nimble_strftime_test.exs
+++ b/test/nimble_strftime_test.exs
@@ -173,11 +173,20 @@ defmodule NimbleStrftimeTest do
       assert NimbleStrftime.format(
                ~U[2019-08-15 17:07:57.001Z],
                "%A %p %B %c %x %X",
-               am_pm_names: {"a", "p"},
-               month_names:
-                 ~w(Janeiro Fevereiro Março Abril Maio Junho Julho Agosto Setembro Outubro Novembro Dezembro),
-               day_of_week_names:
-                 ~w(понедельник вторник среда четверг пятница суббота воскресенье),
+               am_pm_names: fn
+                 :am -> "a"
+                 :pm -> "p"
+               end,
+               month_names: fn index ->
+                 {"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto",
+                  "Setembro", "Outubro", "Novembro", "Dezembro"}
+                 |> elem(index - 1)
+               end,
+               day_of_week_names: fn index ->
+                 {"понедельник", "вторник", "среда", "четверг", "пятница", "суббота",
+                  "воскресенье"}
+                 |> elem(index - 1)
+               end,
                preferred_date: "%05Y-%m-%d",
                preferred_time: "%M:%_3H%S",
                preferred_datetime: "%%"

--- a/test/nimble_strftime_test.exs
+++ b/test/nimble_strftime_test.exs
@@ -173,19 +173,19 @@ defmodule NimbleStrftimeTest do
       assert NimbleStrftime.format(
                ~U[2019-08-15 17:07:57.001Z],
                "%A %p %B %c %x %X",
-               am_pm: fn
+               am_pm_names: fn
                  :am -> "a"
                  :pm -> "p"
                end,
-               month: fn index ->
+               month_names: fn month ->
                  {"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto",
                   "Setembro", "Outubro", "Novembro", "Dezembro"}
-                 |> elem(index - 1)
+                 |> elem(month - 1)
                end,
-               day_of_week: fn index ->
+               day_of_week_names: fn day_of_week ->
                  {"понедельник", "вторник", "среда", "четверг", "пятница", "суббота",
                   "воскресенье"}
-                 |> elem(index - 1)
+                 |> elem(day_of_week - 1)
                end,
                preferred_date: "%05Y-%m-%d",
                preferred_time: "%M:%_3H%S",

--- a/test/nimble_strftime_test.exs
+++ b/test/nimble_strftime_test.exs
@@ -173,16 +173,16 @@ defmodule NimbleStrftimeTest do
       assert NimbleStrftime.format(
                ~U[2019-08-15 17:07:57.001Z],
                "%A %p %B %c %x %X",
-               am_pm_names: fn
+               am_pm: fn
                  :am -> "a"
                  :pm -> "p"
                end,
-               month_names: fn index ->
+               month: fn index ->
                  {"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto",
                   "Setembro", "Outubro", "Novembro", "Dezembro"}
                  |> elem(index - 1)
                end,
-               day_of_week_names: fn index ->
+               day_of_week: fn index ->
                  {"понедельник", "вторник", "среда", "четверг", "пятница", "суббота",
                   "воскресенье"}
                  |> elem(index - 1)


### PR DESCRIPTION
closes #9 
change the `am_pm_names`, `month_names` and `day_of_week_names` to receive functions instead of lists and tuples to comply with the original proposal and make it easier to wrap translation and localization tools around them