### PR TITLE
change abbreviation options to use functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,13 @@ iex> NimbleStrftime.format(
 iex> NimbleStrftime.format(
 ...>  datetime,
 ...>  "%B",
-...>  abbreviation_size: 2,
-...>  month_names: fn month ->
-...>    {"январь", "февраль", "март", "апрель", "май", "июнь",
-...>    "июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь"}
+...>  abbreviated_month_names: fn month ->
+...>    {"янв", "февр", "март", "апр", "май", "июнь",
+...>    "июль", "авг", "сент", "окт", "нояб", "дек"}
 ...>    |> elem(index - 1)
 ...>  end
 ...>)
-# => "ав"
+# => "авг"
 ```
 
 ## Installation

--- a/lib/nimble_strftime.ex
+++ b/lib/nimble_strftime.ex
@@ -89,12 +89,17 @@ defmodule NimbleStrftime do
       the corresponding month, if the option is not received it defaults to a
       function thet returns the month names in english
 
+    * `:abbreviated_month_names` - a function that receives a number and returns the
+      abbreviated name of the corresponding month, if the option is not received it
+      defaults to a function thet returns the abbreviated month names in english
+
     * `:day_of_week_names` - a function that receives a number and returns the name of
       the corresponding day of week, if the option is not received it defaults to a
       function that returns the day of week names in english
 
-    * `:abbreviation_size` - number of characters shown in abbreviated
-      month and week day names, if the option is not received the default of 3 is set
+    * `:abbreviated_day_of_week_names` - a function that receives a number and returns
+      the abbreviated name of the corresponding day of week, if the option is not received 
+      it defaults to a function that returns the abbreviated day of week names in english
 
   ## Examples
 
@@ -200,17 +205,6 @@ defmodule NimbleStrftime do
     format_options.am_pm_names.(:am)
   end
 
-  defp month_name_abbreviated(month, format_options) do
-    String.slice(format_options.month_names.(month), 0..(format_options.abbreviation_size - 1))
-  end
-
-  defp day_of_week_name_abbreviated(day_of_week, format_options) do
-    String.slice(
-      format_options.day_of_week_names.(day_of_week),
-      0..(format_options.abbreviation_size - 1)
-    )
-  end
-
   defp default_pad(format) when format in 'aAbBpPZ', do: ?\s
   defp default_pad(_format), do: ?0
 
@@ -229,7 +223,7 @@ defmodule NimbleStrftime do
     result =
       datetime
       |> Date.day_of_week()
-      |> day_of_week_name_abbreviated(format_options)
+      |> format_options.abbreviated_day_of_week_names.()
       |> pad_leading(width, pad)
 
     parse(rest, datetime, format_options, [result | acc])
@@ -250,7 +244,7 @@ defmodule NimbleStrftime do
   defp format_modifiers("b" <> rest, width, pad, datetime, format_options, acc) do
     result =
       datetime.month
-      |> month_name_abbreviated(format_options)
+      |> format_options.abbreviated_month_names.()
       |> pad_leading(width, pad)
 
     parse(rest, datetime, format_options, [result | acc])
@@ -489,7 +483,13 @@ defmodule NimbleStrftime do
         {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
         |> elem(day_of_week - 1)
       end,
-      abbreviation_size: 3,
+      abbreviated_month_names: fn month ->
+        {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
+        |> elem(month - 1)
+      end,
+      abbreviated_day_of_week_names: fn day_of_week ->
+        {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"} |> elem(day_of_week - 1)
+      end,
       preferred_datetime_invoked: false,
       preferred_date_invoked: false,
       preferred_time_invoked: false

--- a/test/nimble_strftime_test.exs
+++ b/test/nimble_strftime_test.exs
@@ -172,7 +172,7 @@ defmodule NimbleStrftimeTest do
     test "format according to received custom configs" do
       assert NimbleStrftime.format(
                ~U[2019-08-15 17:07:57.001Z],
-               "%A %p %B %c %x %X",
+               "%A %a %p %B %b %c %x %X",
                am_pm_names: fn
                  :am -> "a"
                  :pm -> "p"
@@ -187,10 +187,19 @@ defmodule NimbleStrftimeTest do
                   "воскресенье"}
                  |> elem(day_of_week - 1)
                end,
+               abbreviated_month_names: fn month ->
+                 {"Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov",
+                  "Dez"}
+                 |> elem(month - 1)
+               end,
+               abbreviated_day_of_week_names: fn day_of_week ->
+                 {"ПНД", "ВТР", "СРД", "ЧТВ", "ПТН", "СБТ", "ВСК"}
+                 |> elem(day_of_week - 1)
+               end,
                preferred_date: "%05Y-%m-%d",
                preferred_time: "%M:%_3H%S",
                preferred_datetime: "%%"
-             ) == "четверг P Agosto % 02019-08-15 07: 1757"
+             ) == "четверг ЧТВ P Agosto Ago % 02019-08-15 07: 1757"
     end
   end
 end

--- a/test/nimble_strftime_test.exs
+++ b/test/nimble_strftime_test.exs
@@ -98,7 +98,7 @@ defmodule NimbleStrftimeTest do
       assert NimbleStrftime.format(am_time, "%P %p") == "am AM"
     end
 
-    test "format all weekdays correctly with %A and %a options" do
+    test "format all weekdays correctly with %A and %a formats" do
       sunday = ~U[2019-08-25 11:59:59.001Z]
       monday = ~U[2019-08-26 11:59:59.001Z]
       tuesday = ~U[2019-08-27 11:59:59.001Z]
@@ -116,7 +116,7 @@ defmodule NimbleStrftimeTest do
       assert NimbleStrftime.format(saturday, "%A %a") == "Saturday Sat"
     end
 
-    test "format all months correctly with the %B and %b options" do
+    test "format all months correctly with the %B and %b formats" do
       assert NimbleStrftime.format(%{month: 1}, "%B %b") == "January Jan"
       assert NimbleStrftime.format(%{month: 2}, "%B %b") == "February Feb"
       assert NimbleStrftime.format(%{month: 3}, "%B %b") == "March Mar"
@@ -129,6 +129,162 @@ defmodule NimbleStrftimeTest do
       assert NimbleStrftime.format(%{month: 10}, "%B %b") == "October Oct"
       assert NimbleStrftime.format(%{month: 11}, "%B %b") == "November Nov"
       assert NimbleStrftime.format(%{month: 12}, "%B %b") == "December Dec"
+    end
+
+    test "format all weekdays correctly on %A with day_of_week_names option" do
+      sunday = ~U[2019-08-25 11:59:59.001Z]
+      monday = ~U[2019-08-26 11:59:59.001Z]
+      tuesday = ~U[2019-08-27 11:59:59.001Z]
+      wednesday = ~U[2019-08-28 11:59:59.001Z]
+      thursday = ~U[2019-08-29 11:59:59.001Z]
+      friday = ~U[2019-08-30 11:59:59.001Z]
+      saturday = ~U[2019-08-31 11:59:59.001Z]
+
+      day_of_week_names = fn day_of_week ->
+        {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado",
+         "domingo"}
+        |> elem(day_of_week - 1)
+      end
+
+      assert NimbleStrftime.format(sunday, "%A", day_of_week_names: day_of_week_names) ==
+               "domingo"
+
+      assert NimbleStrftime.format(monday, "%A", day_of_week_names: day_of_week_names) ==
+               "segunda-feira"
+
+      assert NimbleStrftime.format(tuesday, "%A", day_of_week_names: day_of_week_names) ==
+               "terça-feira"
+
+      assert NimbleStrftime.format(wednesday, "%A", day_of_week_names: day_of_week_names) ==
+               "quarta-feira"
+
+      assert NimbleStrftime.format(thursday, "%A", day_of_week_names: day_of_week_names) ==
+               "quinta-feira"
+
+      assert NimbleStrftime.format(friday, "%A", day_of_week_names: day_of_week_names) ==
+               "sexta-feira"
+
+      assert NimbleStrftime.format(saturday, "%A", day_of_week_names: day_of_week_names) ==
+               "sábado"
+    end
+
+    test "format all months correctly on the %B with month_names option" do
+      month_names = fn month ->
+        {"январь", "февраль", "март", "апрель", "май", "июнь", "июль", "август", "сентябрь",
+         "октябрь", "ноябрь", "декабрь"}
+        |> elem(month - 1)
+      end
+
+      assert NimbleStrftime.format(%{month: 1}, "%B", month_names: month_names) == "январь"
+      assert NimbleStrftime.format(%{month: 2}, "%B", month_names: month_names) == "февраль"
+      assert NimbleStrftime.format(%{month: 3}, "%B", month_names: month_names) == "март"
+      assert NimbleStrftime.format(%{month: 4}, "%B", month_names: month_names) == "апрель"
+      assert NimbleStrftime.format(%{month: 5}, "%B", month_names: month_names) == "май"
+      assert NimbleStrftime.format(%{month: 6}, "%B", month_names: month_names) == "июнь"
+      assert NimbleStrftime.format(%{month: 7}, "%B", month_names: month_names) == "июль"
+      assert NimbleStrftime.format(%{month: 8}, "%B", month_names: month_names) == "август"
+      assert NimbleStrftime.format(%{month: 9}, "%B", month_names: month_names) == "сентябрь"
+      assert NimbleStrftime.format(%{month: 10}, "%B", month_names: month_names) == "октябрь"
+      assert NimbleStrftime.format(%{month: 11}, "%B", month_names: month_names) == "ноябрь"
+      assert NimbleStrftime.format(%{month: 12}, "%B", month_names: month_names) == "декабрь"
+    end
+
+    test "format all weekdays correctly on the %a format with abbreviated_day_of_week_names option" do
+      sunday = ~U[2019-08-25 11:59:59.001Z]
+      monday = ~U[2019-08-26 11:59:59.001Z]
+      tuesday = ~U[2019-08-27 11:59:59.001Z]
+      wednesday = ~U[2019-08-28 11:59:59.001Z]
+      thursday = ~U[2019-08-29 11:59:59.001Z]
+      friday = ~U[2019-08-30 11:59:59.001Z]
+      saturday = ~U[2019-08-31 11:59:59.001Z]
+
+      abbreviated_day_of_week_names = fn day_of_week ->
+        {"seg", "ter", "qua", "qui", "sex", "sáb", "dom"}
+        |> elem(day_of_week - 1)
+      end
+
+      assert NimbleStrftime.format(sunday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "dom"
+
+      assert NimbleStrftime.format(monday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "seg"
+
+      assert NimbleStrftime.format(tuesday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "ter"
+
+      assert NimbleStrftime.format(wednesday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "qua"
+
+      assert NimbleStrftime.format(thursday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "qui"
+
+      assert NimbleStrftime.format(friday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "sex"
+
+      assert NimbleStrftime.format(saturday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "sáb"
+    end
+
+    test "format all months correctly on the %b format with abbreviated_month_names option" do
+      abbreviated_month_names = fn month ->
+        {"янв", "февр", "март", "апр", "май", "июнь", "июль", "авг", "сент", "окт", "нояб", "дек"}
+        |> elem(month - 1)
+      end
+
+      assert NimbleStrftime.format(%{month: 1}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "янв"
+
+      assert NimbleStrftime.format(%{month: 2}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "февр"
+
+      assert NimbleStrftime.format(%{month: 3}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "март"
+
+      assert NimbleStrftime.format(%{month: 4}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "апр"
+
+      assert NimbleStrftime.format(%{month: 5}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "май"
+
+      assert NimbleStrftime.format(%{month: 6}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "июнь"
+
+      assert NimbleStrftime.format(%{month: 7}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "июль"
+
+      assert NimbleStrftime.format(%{month: 8}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "авг"
+
+      assert NimbleStrftime.format(%{month: 9}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "сент"
+
+      assert NimbleStrftime.format(%{month: 10}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "окт"
+
+      assert NimbleStrftime.format(%{month: 11}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "нояб"
+
+      assert NimbleStrftime.format(%{month: 12}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "дек"
     end
 
     test "microseconds format ignores padding and width options" do


### PR DESCRIPTION
closes #10 
this pull request removes the `abbreviation_size` option and replaces it with two new ones called `abbreviated_day_of_week_names` and `abbreviated_month_names` since `abbreviation_size` wouldn't satisfy requirements for abbreviated names in some locales 